### PR TITLE
Update README with Gmail App Password instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,6 +11,18 @@ pip install -r requirements.txt
 python email_sender.py
 ```
 
+## Creating a Gmail App Password
+
+The app uses Gmail's SMTP service, which requires an App Password if you have
+2-Step Verification enabled. Follow these steps:
+
+1. Enable 2-Step Verification on your Google Account.
+2. Go to your account's [App passwords](https://myaccount.google.com/apppasswords) page.
+3. Generate a new password for "Mail" and copy the value.
+
+See Google's [official guide](https://support.google.com/accounts/answer/185833)
+for more details.
+
 ## Packaging
 
 A PyInstaller spec file (`email_sender.spec`) and a GitHub Actions workflow have been added so the repository automatically builds a Windows executable on pushes to `main`. If you wish to build locally, run:


### PR DESCRIPTION
## Summary
- document how to create a Gmail App Password in README

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6843d4669af08329bc9eda59877fcf69