### PR TITLE
Add PG&E integration modules

### DIFF
--- a/Api.py
+++ b/Api.py
@@ -1,0 +1,50 @@
+import requests
+import logging
+
+class Api:
+    """Interact with PG&E usage data endpoints."""
+
+    def __init__(self, cert_crt_path: str, cert_key_path: str):
+        self._cert = (cert_crt_path, cert_key_path)
+        self.logger = logging.getLogger(self.__class__.__name__)
+        self.logger.debug("Api initialized")
+
+    def sync_request(self, base_url: str, subscription_id: str, usage_point_id: str,
+                     published_min: str, published_max: str, access_token: str) -> dict:
+        url = f"{base_url}/Subscription/{subscription_id}/UsagePoint/{usage_point_id}"
+        url += f"?published-min={published_min}&published-max={published_max}"
+        headers = {"Authorization": f"Bearer {access_token}"}
+        try:
+            resp = requests.get(url, headers=headers, cert=self._cert)
+        except Exception as exc:
+            self.logger.error("Sync request failed: %s", exc)
+            return {"status": None, "error": str(exc)}
+
+        result = {"status": resp.status_code}
+        if resp.status_code == 200:
+            result["data"] = resp.text
+            self.logger.info("Sync data retrieved")
+        else:
+            result["error"] = resp.text
+            self.logger.warning("Sync request failed: %s", resp.text)
+        return result
+
+    def async_request(self, base_url: str, subscription_id: str,
+                      published_min: str, published_max: str, access_token: str) -> dict:
+        url = f"{base_url}/Subscription/{subscription_id}"
+        url += f"?published-min={published_min}&published-max={published_max}"
+        headers = {"Authorization": f"Bearer {access_token}"}
+        try:
+            resp = requests.get(url, headers=headers, cert=self._cert)
+        except Exception as exc:
+            self.logger.error("Async request failed: %s", exc)
+            return {"status": None, "error": str(exc)}
+
+        result = {"status": resp.status_code}
+        if resp.status_code in (200, 202):
+            result["data"] = resp.text
+            self.logger.info("Async request initiated")
+        else:
+            result["error"] = resp.text
+            self.logger.warning("Async request failed: %s", resp.text)
+        return result

--- a/ClientCredentials.py
+++ b/ClientCredentials.py
@@ -1,0 +1,37 @@
+import base64
+import requests
+import logging
+
+class ClientCredentials:
+    """Obtain client access token using the client_credentials grant."""
+
+    def __init__(self, client_id: str, client_secret: str,
+                 cert_crt_path: str, cert_key_path: str):
+        auth_str = f"{client_id}:{client_secret}"
+        self._basic_auth_header = "Basic " + base64.b64encode(auth_str.encode()).decode()
+        self._cert = (cert_crt_path, cert_key_path)
+        self.logger = logging.getLogger(self.__class__.__name__)
+        self.logger.debug("ClientCredentials initialized")
+
+    def get_client_token(self, token_url: str) -> dict:
+        """Request a client token."""
+        data = {"grant_type": "client_credentials"}
+        headers = {"Authorization": self._basic_auth_header}
+        try:
+            resp = requests.post(token_url, data=data, headers=headers, cert=self._cert)
+        except Exception as exc:
+            self.logger.error("Client token request failed: %s", exc)
+            return {"status": None, "error": str(exc)}
+
+        result = {"status": resp.status_code}
+        if resp.status_code == 200:
+            try:
+                token_data = resp.json()
+            except ValueError:
+                token_data = {"response_xml": resp.text}
+            result.update(token_data)
+            self.logger.info("Client token obtained")
+        else:
+            result["error"] = resp.text
+            self.logger.warning("Client token request failed: %s", resp.text)
+        return result

--- a/OAuth2.py
+++ b/OAuth2.py
@@ -1,0 +1,67 @@
+import base64
+import requests
+import logging
+
+class OAuth2:
+    """Handle PG&E OAuth2 authorization code and refresh flows."""
+
+    def __init__(self, client_id: str, client_secret: str,
+                 cert_crt_path: str, cert_key_path: str):
+        auth_str = f"{client_id}:{client_secret}"
+        self._basic_auth_header = "Basic " + base64.b64encode(auth_str.encode()).decode()
+        self._cert = (cert_crt_path, cert_key_path)
+        self.logger = logging.getLogger(self.__class__.__name__)
+        self.logger.debug("OAuth2 initialized")
+
+    def get_access_token(self, token_url: str, auth_code: str, redirect_uri: str) -> dict:
+        """Exchange authorization code for access token."""
+        data = {
+            "grant_type": "authorization_code",
+            "code": auth_code,
+            "redirect_uri": redirect_uri
+        }
+        headers = {"Authorization": self._basic_auth_header}
+        try:
+            resp = requests.post(token_url, data=data, headers=headers, cert=self._cert)
+        except Exception as exc:
+            self.logger.error("Access token request failed: %s", exc)
+            return {"status": None, "error": str(exc)}
+
+        result = {"status": resp.status_code}
+        if resp.status_code == 200:
+            try:
+                token_data = resp.json()
+            except ValueError:
+                token_data = {"response_xml": resp.text}
+            result.update(token_data)
+            self.logger.info("Access token obtained")
+        else:
+            result["error"] = resp.text
+            self.logger.warning("Access token request failed: %s", resp.text)
+        return result
+
+    def get_refresh_token(self, token_url: str, refresh_token: str) -> dict:
+        """Use refresh token to obtain new access token."""
+        data = {
+            "grant_type": "refresh_token",
+            "refresh_token": refresh_token
+        }
+        headers = {"Authorization": self._basic_auth_header}
+        try:
+            resp = requests.post(token_url, data=data, headers=headers, cert=self._cert)
+        except Exception as exc:
+            self.logger.error("Refresh token request failed: %s", exc)
+            return {"status": None, "error": str(exc)}
+
+        result = {"status": resp.status_code}
+        if resp.status_code == 200:
+            try:
+                token_data = resp.json()
+            except ValueError:
+                token_data = {"response_xml": resp.text}
+            result.update(token_data)
+            self.logger.info("Token refreshed")
+        else:
+            result["error"] = resp.text
+            self.logger.warning("Refresh token request failed: %s", resp.text)
+        return result

--- a/README.md
+++ b/README.md
@@ -33,3 +33,21 @@ pyinstaller --onefile --noconsole email_sender.spec
 ```
 
 The resulting executable will appear in the `dist` directory.
+
+---
+
+## PG&E Green Button Integration
+
+The repository also contains sample modules for integrating with PG&E's
+Share My Data API using OAuth2 and mutual TLS. Key files include:
+
+- `OAuth2.py` – exchanges authorization codes for access tokens and refreshes
+  tokens.
+- `ClientCredentials.py` – obtains a client access token for connectivity tests.
+- `Api.py` – makes authenticated data requests.
+- `pge_example.py` – minimal Flask app demonstrating the OAuth callback flow.
+
+These modules require the `requests` and `Flask` packages in addition to the
+original requirements. Update `requirements.txt` accordingly and replace the
+placeholders in `pge_example.py` with the credentials and certificate paths
+provided by PG&E.

--- a/pge_example.py
+++ b/pge_example.py
@@ -1,0 +1,45 @@
+"""Simple Flask example demonstrating PG&E OAuth flow."""
+
+from flask import Flask, redirect, request
+from OAuth2 import OAuth2
+
+app = Flask(__name__)
+
+# Configuration placeholders - replace with real values
+CLIENT_ID = "your_client_id"
+CLIENT_SECRET = "your_client_secret"
+REDIRECT_URI = "https://yourapp.com/oauth/callback"
+AUTH_URL = "https://api.pge.com/datacustodian/oauth/v2/authorize"
+TOKEN_URL = "https://api.pge.com/datacustodian/oauth/v2/token"
+CERT_CRT = "path/to/client.crt"
+CERT_KEY = "path/to/client.key"
+
+oauth_client = OAuth2(CLIENT_ID, CLIENT_SECRET, CERT_CRT, CERT_KEY)
+
+@app.route("/")
+def index():
+    return '<a href="/login">Connect to PG&E</a>'
+
+@app.route("/login")
+def login():
+    from urllib.parse import urlencode
+    params = {
+        "client_id": CLIENT_ID,
+        "redirect_uri": REDIRECT_URI,
+        "response_type": "code",
+        "scope": "DEFAULT",
+    }
+    return redirect(AUTH_URL + "?" + urlencode(params))
+
+@app.route("/oauth/callback")
+def callback():
+    code = request.args.get("code") or request.args.get("authorization_code")
+    if not code:
+        return "Missing authorization code", 400
+    result = oauth_client.get_access_token(TOKEN_URL, code, REDIRECT_URI)
+    if result.get("status") != 200:
+        return "Token exchange failed: " + result.get("error", ""), 500
+    return result
+
+if __name__ == "__main__":
+    app.run(debug=True)

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,4 @@
 pandas==2.2.2
 openpyxl==3.1.2
+requests
+Flask


### PR DESCRIPTION
## Summary
- add OAuth2 helper for PG&E token exchange
- add ClientCredentials helper for client tokens
- add Api wrapper for usage data requests
- provide a Flask demo app showing OAuth redirect flow
- document PG&E integration modules
- update requirements

## Testing
- `python -m py_compile OAuth2.py ClientCredentials.py Api.py pge_example.py email_sender.py`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68471f648e408329b1e04151e46c3cd1