### PR TITLE
Document PG&E env vars and use them in example

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,6 +48,10 @@ Share My Data API using OAuth2 and mutual TLS. Key files include:
 - `pge_example.py` – minimal Flask app demonstrating the OAuth callback flow.
 
 These modules require the `requests` and `Flask` packages in addition to the
-original requirements. Update `requirements.txt` accordingly and replace the
-placeholders in `pge_example.py` with the credentials and certificate paths
-provided by PG&E.
+original requirements. Before running `pge_example.py`, set the following
+environment variables with the credentials and certificate paths provided by PG&E:
+
+- `PGE_CLIENT_ID` – your client ID
+- `PGE_CLIENT_SECRET` – your client secret
+- `PGE_CERT_CRT` – path to the `.crt` certificate file
+- `PGE_CERT_KEY` – path to the corresponding private key

--- a/pge_example.py
+++ b/pge_example.py
@@ -2,17 +2,18 @@
 
 from flask import Flask, redirect, request
 from OAuth2 import OAuth2
+import os
 
 app = Flask(__name__)
 
-# Configuration placeholders - replace with real values
-CLIENT_ID = "your_client_id"
-CLIENT_SECRET = "your_client_secret"
+# Configuration via environment variables
+CLIENT_ID = os.getenv("PGE_CLIENT_ID")
+CLIENT_SECRET = os.getenv("PGE_CLIENT_SECRET")
 REDIRECT_URI = "https://yourapp.com/oauth/callback"
 AUTH_URL = "https://api.pge.com/datacustodian/oauth/v2/authorize"
 TOKEN_URL = "https://api.pge.com/datacustodian/oauth/v2/token"
-CERT_CRT = "path/to/client.crt"
-CERT_KEY = "path/to/client.key"
+CERT_CRT = os.getenv("PGE_CERT_CRT")
+CERT_KEY = os.getenv("PGE_CERT_KEY")
 
 oauth_client = OAuth2(CLIENT_ID, CLIENT_SECRET, CERT_CRT, CERT_KEY)
 


### PR DESCRIPTION
## Summary
- load PG&E credentials in `pge_example.py` from environment variables
- explain required environment variables in README

## Testing
- `python -m py_compile pge_example.py OAuth2.py Api.py ClientCredentials.py email_sender.py`
- `flake8` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6847223146c0832986300f3c8de93b85